### PR TITLE
Ensure 'service trafficserver stop’ is synchronous under load

### DIFF
--- a/rc/trafficserver.in
+++ b/rc/trafficserver.in
@@ -314,9 +314,9 @@ case "$1" in
             test "x$VERBOSE" != "xno" && log_end_msg "$retval"
             exit "$retval"
         elif [ "$DISTRIB_ID" = "fedora" -o "$DISTRIB_ID" = "redhat" ]; then
-            action "Stopping ${TC_NAME}:" killproc -p $TC_PIDFILE $TC_DAEMON
-            action "Stopping ${TM_NAME}:" killproc -p $TM_PIDFILE $TM_DAEMON
-            action "Stopping ${TS_NAME}:" killproc -p $TS_PIDFILE $TS_DAEMON
+            action "Stopping ${TC_NAME}:" killproc -d 35 -p $TC_PIDFILE $TC_DAEMON
+            action "Stopping ${TM_NAME}:" killproc -d 35 -p $TM_PIDFILE $TM_DAEMON
+            action "Stopping ${TS_NAME}:" killproc -d 35 -p $TS_PIDFILE $TS_DAEMON
         elif [ "$DISTRIB_ID" = "gentoo" ]; then
 	    ebegin "Starting ${TS_PACKAGE_NAME}"
 	    do_stop


### PR DESCRIPTION
Currently the service trafficserver stop command on redhat might return before ATS has exited.
This is not good as it’s often followed by a start, which then fails.

/etc/init.d/trafficserver does:

            action "Stopping ${TC_NAME}:" killproc -p $TC_PIDFILE $TC_DAEMON
            action "Stopping ${TM_NAME}:" killproc -p $TM_PIDFILE $TM_DAEMON
            action "Stopping ${TS_NAME}:" killproc -p $TS_PIDFILE $TS_DAEMON

and killproc, as defined in /etc/rc.d/init.d/functions, with those arguments essentially does this:

	send SIGTERM
	wait up to 3 seconds for it to exit
	send SIGKILL
	wait 0.1 seconds then return an exit status indicating if the process still exists

A SIGKILL signal always causes the death of a process but it’s not instantaneous. A process can take a long time to exit on a busy system for assorted reasons, including flushing dirty buffers to disk.

So if the stop is immediately followed by a start, as it often is, the start may fail with an error like ‘port 80 in use’. This seems to be a common cause of restart failures on busy systems and frustrating manual hand-holding.

Contrast this with the behaviour that /etc/init.d/trafficserver uses when run on Ubuntu… there it’ll wait up to 35 seconds.
(It'll also use SIGQUIT instead of SIGTERM which seems odd).

This PR makes /etc/init.d/trafficserver more reliable, and consistent, on redhat by adding `-d 35` to the killproc arguments so it'll wait for the daemons to stop on redhat for about as long as it does in ubuntu.